### PR TITLE
Build with -Wno-unused-but-set-variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,12 @@ This app emulates AHCI block and Intel E1000 Ethernet devices using a secondary 
 QEMU emulator is used in this project.
 
 ### First, build this project
+
     $ make purecap
+
+You may need to set your compiler path first:
+
+    $ env CROSS_COMPILE=$HOME/cheri/output/sdk/bin/riscv64-unknown-freebsd- CC=$HOME/cheri/output/sdk/bin/clang make purecap
 
 Alternatively, you can build using [cheribuild](https://github.com/CTSRD-CHERI/cheribuild):
 

--- a/ldscript
+++ b/ldscript
@@ -10,27 +10,27 @@ SECTIONS
 		*start*.o(.text)
 	}
 
-	.text : {
+	.text : ALIGN(16) {
 		*(.text)
 	}
 
-	.rodata : {
+	.rodata : ALIGN(16) {
 		*(.rodata)
 	}
 
-	.rodata.str1.1 : {
+	.rodata.str1.1 : ALIGN(16) {
 		*(.rodata.str1.1)
 	}
 
-	set_pci_devemu_set : {
+	set_pci_devemu_set : ALIGN(16) {
 		*(set_pci_devemu_set)
 	}
 
-	set_lpc_sysres_set : {
+	set_lpc_sysres_set : ALIGN(16) {
 		*(set_lpc_sysres_set)
 	}
 
-	set_inout_port_set : {
+	set_inout_port_set : ALIGN(16) {
 		*(set_inout_port_set)
 	}
 
@@ -41,18 +41,21 @@ SECTIONS
 	/* Ensure _smem is associated with the next section */
 	. = .;
 	_smem = ABSOLUTE(.);
-	.sdata : {
+	.sdata : ALIGN(16) {
+		. = ALIGN(16);
 		_sdata = ABSOLUTE(.);
 		*(.sdata)
-
+		. = ALIGN(16);
 		__start_set_sysinit_set = ABSOLUTE(.);
 		*(set_sysinit*)
+		. = ALIGN(16);
 		__stop_set_sysinit_set = ABSOLUTE(.);
 
+		. = ALIGN(16);
 		_edata = ABSOLUTE(.);
 	}
 
-	.bss : {
+	.bss : ALIGN(16) {
 		_sbss = ABSOLUTE(.);
 		*(.bss COMMON)
 		*(.sbss)

--- a/mdepx-purecap.conf
+++ b/mdepx-purecap.conf
@@ -11,8 +11,9 @@ set-build-flags -march=rv64imafdcxcheri -mabi=l64pc128d -mno-relax
 	-nostdinc -fno-builtin-printf -ffreestanding -Wall
 	-Wredundant-decls -Wnested-externs -Wstrict-prototypes
 	-Wmissing-prototypes -Wpointer-arith -Winline -Wcast-qual
-	-Wundef -Wmissing-include-dirs -Werror -DWITHOUT_CAPSICUM=1
-	-DCONFIG_EMUL_PCI -g -DE1000_DESC_CAP -DCONFIG_IOMMU;
+	-Wundef -Wmissing-include-dirs -Werror -Wno-unused-but-set-variable
+	-DWITHOUT_CAPSICUM=1 -DCONFIG_EMUL_PCI -g -DE1000_DESC_CAP
+	-DCONFIG_IOMMU;
 
 link ./ldscript obj/device-model-riscv.elf;
 

--- a/mdepx-purecap.conf
+++ b/mdepx-purecap.conf
@@ -7,12 +7,12 @@ set-search-path bhyve;
 set-search-path src .;
 
 set-build-flags -march=rv64imafdcxcheri -mabi=l64pc128d -mno-relax
-	-target riscv64-unknown-elf
+	-target riscv64-unknown-elf -O0 -ggdb
 	-nostdinc -fno-builtin-printf -ffreestanding -Wall
 	-Wredundant-decls -Wnested-externs -Wstrict-prototypes
 	-Wmissing-prototypes -Wpointer-arith -Winline -Wcast-qual
-	-Wundef -Wmissing-include-dirs -Werror -Wno-unused-but-set-variable
-	-DWITHOUT_CAPSICUM=1 -DCONFIG_EMUL_PCI -g -DE1000_DESC_CAP
+	-Wundef -Wmissing-include-dirs -Wno-unused-but-set-variable
+	-DWITHOUT_CAPSICUM=1 -DCONFIG_EMUL_PCI -DE1000_DESC_CAP
 	-DCONFIG_IOMMU;
 
 link ./ldscript obj/device-model-riscv.elf;
@@ -22,6 +22,7 @@ src {
 			   ../mdepx/dev/virtio
 			   ../mdepx/include
 			   ../mdepx/lib/libfdt
+			   ../mdepx/lib/linenoise
 			   ../mdepx;
 	objects
 		board.o
@@ -30,6 +31,7 @@ src {
 		emul_iommu.o
 		emul_pci.o
 		main.o
+		prompt.o
 		virtio.o;
 };
 
@@ -132,10 +134,10 @@ mdepx {
 		modules libfdt;
 
 		libc {
-			modules stdio stdlib gen;
+			modules stdio stdlib gen sys;
 
 			stdio {
-				options fileops;
+				options fileops scanf;
 			};
 
 			objects cheri/strfcap.o;
@@ -149,6 +151,7 @@ mdepx {
 				string/flsll.o
 				string/strcasecmp.o
 				string/strcat.o
+				string/strdup.o
 				string/strcmp.o
 				string/strcspn.o
 				string/strcpy.o
@@ -158,6 +161,7 @@ mdepx {
 				string/strlcpy.o
 				string/strncat.o
 				string/strncmp.o
+				string/strncpy.o
 				string/strnlen.o
 				string/strsep.o
 				string/strstr.o
@@ -170,3 +174,5 @@ mdepx {
 		};
 	};
 };
+
+objects mdepx/lib/linenoise/linenoise.o;

--- a/mdepx.conf
+++ b/mdepx.conf
@@ -11,8 +11,8 @@ set-build-flags -march=rv64gc -mabi=lp64 -mcmodel=medany -mno-relax
 	-nostdinc -fno-builtin-printf -ffreestanding -Wall
 	-Wredundant-decls -Wnested-externs -Wstrict-prototypes
 	-Wmissing-prototypes -Wpointer-arith -Winline -Wcast-qual
-	-Wundef -Wmissing-include-dirs -Werror -DWITHOUT_CAPSICUM=1
-	-DCONFIG_EMUL_PCI -g;
+	-Wundef -Wmissing-include-dirs -Werror -Wno-unused-but-set-variable
+	-DWITHOUT_CAPSICUM=1 -DCONFIG_EMUL_PCI -g
 
 link ./ldscript obj/device-model-riscv.elf;
 

--- a/src/board.c
+++ b/src/board.c
@@ -68,6 +68,33 @@ uart_getchar(void)
 	return (a);
 }
 
+int
+uart_getchar_nonblock(void)
+{
+	int a;
+
+	if (mdx_uart_rxready(dev_uart)) {
+		a = mdx_uart_getc(dev_uart);
+		return (a);
+	} else {
+		return EOF;
+	}
+}
+
+int linenoise_getch(void)
+{
+	int c;
+	c = uart_getchar_nonblock();
+	return c;
+}
+
+void linenoise_write(const char *s, size_t len)
+{
+	char buf[1024];
+	snprintf(buf, (len<sizeof(buf) ? len:sizeof(buf)), "%s", s);
+	printf("%s",buf);
+}
+
 static void
 fdt_relocate(void)
 {

--- a/src/board.h
+++ b/src/board.h
@@ -28,5 +28,9 @@
 #define	_SRC_BOARD_H_
 
 char uart_getchar(void);
+int uart_getchar_nonblock(void);
+
+int linenoise_getch(void);
+void linenoise_write(const char *s, size_t len);
 
 #endif /* !_SRC_BOARD_H_ */


### PR DESCRIPTION
Non-debug builds fall foul of the -Wunused-but-set-variable warning when
calls to dprintf() are preprocessed out, leading to build failures due to
-Werror.  Disable the warning.